### PR TITLE
ci: set checkout depth to 0 for nerdbank versioning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Full history for versioning
 
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
Updated checkout step to include full history for versioning.